### PR TITLE
fix: update the package name in the documentation and example

### DIFF
--- a/LLM_DOC.md
+++ b/LLM_DOC.md
@@ -761,7 +761,7 @@ import {
   APIError,
   AuthenticationError,
   NetworkError
-} from 'nutrient-dws-client-typescript';
+} from '@nutrient-sdk/dws-client-typescript';
 
 try {
   const result = await client.convert('file.docx', 'pdf');

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A Node.js TypeScript client library for [Nutrient Document Web Services (DWS) API](https://nutrient.io/). This library provides a type-safe and ergonomic interface for document processing operations including conversion, merging, compression, watermarking, and text extraction.
 
-> **Note**: This package is published as `nutrient-dws-client-typescript` on NPM. The package provides full TypeScript support and is designed specifically for Node.js environments.
+> **Note**: This package is published as `@nutrient-sdk/dws-client-typescript` on NPM. The package provides full TypeScript support and is designed specifically for Node.js environments.
 
 ## Features
 
@@ -25,13 +25,13 @@ A Node.js TypeScript client library for [Nutrient Document Web Services (DWS) AP
 ## Installation
 
 ```bash
-npm install nutrient-dws-client-typescript
+npm install @nutrient-sdk/dws-client-typescript
 ```
 
 or
 
 ```bash
-yarn add nutrient-dws-client-typescript
+yarn add @nutrient-sdk/dws-client-typescript
 ```
 
 ## Integration with Coding Agents
@@ -147,7 +147,7 @@ import {
   APIError,
   AuthenticationError,
   NetworkError
-} from 'nutrient-dws-client-typescript';
+} from '@nutrient-sdk/dws-client-typescript';
 
 try {
   const result = await client.convert('file.docx', 'pdf');

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -8,18 +8,38 @@
       "name": "nutrient-dws-client-typescript-example",
       "version": "1.0.0",
       "dependencies": {
-        "dotenv": "^17.0.0",
-        "nutrient-dws-client-typescript": "file:../nutrient-dws-client-typescript-1.0.0.tgz"
+        "@nutrient-sdk/dws-client-typescript": "file:../nutrient-sdk-dws-client-typescript-1.0.0.tgz",
+        "dotenv": "^17.0.0"
       },
       "devDependencies": {
         "@types/node": "^24.0.7",
         "typescript": "^5.8.3"
       }
     },
+    "node_modules/@nutrient-sdk/dws-client-typescript": {
+      "version": "1.0.0",
+      "resolved": "file:../nutrient-sdk-dws-client-typescript-1.0.0.tgz",
+      "integrity": "sha512-Mj/60kdAEbjKPwsnk4u2CitNf9ZVDjYOaqmbbBFaEcfgDRyVpxhkpk+cOYWYSIkxRlm9AQBIPgrT4wETx8rRxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.10.0",
+        "form-data": "^4.0.3"
+      },
+      "bin": {
+        "dws-add-claude-code-rule": "scripts/add_claude_code_rule.cjs",
+        "dws-add-cursor-rule": "scripts/add_cursor_rule.cjs",
+        "dws-add-github-copilot-rule": "scripts/add_github_copilot_rule.cjs",
+        "dws-add-junie-rule": "scripts/add_junie_rule.cjs",
+        "dws-add-windsurf-rule": "scripts/add_windsurf_rule.cjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@types/node": {
-      "version": "24.0.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.13.tgz",
-      "integrity": "sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==",
+      "version": "24.0.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
+      "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -309,26 +329,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/nutrient-dws-client-typescript": {
-      "version": "1.0.0",
-      "resolved": "file:../nutrient-dws-client-typescript-1.0.0.tgz",
-      "integrity": "sha512-CNPHCjp25WjwSsOMfNOeY+ednFy2xAw/FaK22+JcLHsA4+RmofLufBX1W0M44bZmV3bW9WfGd4hKYjRH3ojmYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^1.10.0",
-        "form-data": "^4.0.3"
-      },
-      "bin": {
-        "dws-add-claude-code-rule": "scripts/add_claude_code_rule.cjs",
-        "dws-add-cursor-rule": "scripts/add_cursor_rule.cjs",
-        "dws-add-github-copilot-rule": "scripts/add_github_copliot_rule.cjs",
-        "dws-add-junie-rule": "scripts/add_junie_rule.cjs",
-        "dws-add-windsurf-rule": "scripts/add_windsurf_rule.cjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/proxy-from-env": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nutrient-dws-client-typescript-example",
   "version": "1.0.0",
-  "description": "Example project for nutrient-dws-client-typescript",
+  "description": "Example project for @nutrient-sdk/dws-client-typescript",
   "main": "dist/index.js",
   "scripts": {
     "start:direct": "tsx src/direct_method.ts",
@@ -10,7 +10,7 @@
   "private": true,
   "dependencies": {
     "dotenv": "^17.0.0",
-    "nutrient-dws-client-typescript": "file:../nutrient-dws-client-typescript-1.0.0.tgz"
+    "@nutrient-sdk/dws-client-typescript": "file:../nutrient-sdk-dws-client-typescript-1.0.0.tgz"
   },
   "devDependencies": {
     "@types/node": "^24.0.7",

--- a/examples/src/direct_method.ts
+++ b/examples/src/direct_method.ts
@@ -5,7 +5,7 @@
  * with direct method calls for document processing operations.
  */
 
-import { NutrientClient } from 'nutrient-dws-client-typescript';
+import { NutrientClient } from '@nutrient-sdk/dws-client-typescript';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as dotenv from 'dotenv';

--- a/examples/src/workflow.ts
+++ b/examples/src/workflow.ts
@@ -5,7 +5,7 @@
  * with the workflow builder pattern for document processing operations.
  */
 
-import { NutrientClient, BuildActions } from 'nutrient-dws-client-typescript';
+import { NutrientClient, BuildActions } from '@nutrient-sdk/dws-client-typescript';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as dotenv from 'dotenv';

--- a/scripts/add_claude_code_rule.cjs
+++ b/scripts/add_claude_code_rule.cjs
@@ -16,7 +16,7 @@ const relativeTypePath = path.relative(userProjectRoot, typePath);
 try {
   const rule = `
 # Nutrient DWS TypeScript Client Usage
-- Use the \`nutrient-dws-client-typescript\` package for operations with document processing operations including conversion, merging, compression, watermarking, signage, and text extraction.
+- Use the \`@nutrient-sdk/dws-client-typescript\` package for operations with document processing operations including conversion, merging, compression, watermarking, signage, and text extraction.
 - Package Documentation and Examples can be found at: ${relativeDocPath}
 - TypeScript Type Definitions can be found at: ${relativeTypePath}
 `

--- a/scripts/add_cursor_rule.cjs
+++ b/scripts/add_cursor_rule.cjs
@@ -16,7 +16,7 @@ const relativeTypePath = path.relative(userProjectRoot, typePath);
 try {
   const rule = `
 ---
-description: This rule explains how to use the Nutrient DWS TypeScript Client for operations with document processing operations including conversion, merging, compression, watermarking, signage, and text extraction.
+description: This rule explains how to use the Nutrient DWS TypeScript Client (\`@nutrient-sdk/dws-client-typescript\`) for operations with document processing operations including conversion, merging, compression, watermarking, signage, and text extraction.
 globs: 
 alwaysApply: false
 ---

--- a/scripts/add_github_copilot_rule.cjs
+++ b/scripts/add_github_copilot_rule.cjs
@@ -17,7 +17,7 @@ const relativeTypePath = path.relative(userProjectRoot, typePath);
 try {
   const rule = `
 # Nutrient DWS TypeScript Client Usage
-- Use the \`nutrient-dws-client-typescript\` package for operations with document processing operations including conversion, merging, compression, watermarking, signage, and text extraction.
+- Use the \`@nutrient-sdk/dws-client-typescript\` package for operations with document processing operations including conversion, merging, compression, watermarking, signage, and text extraction.
 - Package Documentation and Examples can be found at: ${relativeDocPath}
 - TypeScript Type Definitions can be found at: ${relativeTypePath}
 `

--- a/scripts/add_junie_rule.cjs
+++ b/scripts/add_junie_rule.cjs
@@ -17,7 +17,7 @@ const relativeTypePath = path.relative(userProjectRoot, typePath);
 try {
   const rule = `
 # Nutrient DWS TypeScript Client Usage
-- Use the \`nutrient-dws-client-typescript\` package for operations with document processing operations including conversion, merging, compression, watermarking, signage, and text extraction.
+- Use the \`@nutrient-sdk/dws-client-typescript\` package for operations with document processing operations including conversion, merging, compression, watermarking, signage, and text extraction.
 - Package Documentation and Examples can be found at: ${relativeDocPath}
 - TypeScript Type Definitions can be found at: ${relativeTypePath}
 `

--- a/scripts/add_windsurf_rule.cjs
+++ b/scripts/add_windsurf_rule.cjs
@@ -16,7 +16,7 @@ const relativeTypePath = path.relative(userProjectRoot, typePath);
 try {
   const rule = `
 ---
-description: This rule explains how to use the Nutrient DWS TypeScript Client for operations with document processing operations including conversion, merging, compression, watermarking, signage, and text extraction.
+description: This rule explains how to use the Nutrient DWS TypeScript Client (\`@nutrient-sdk/dws-client-typescript\`) for operations with document processing operations including conversion, merging, compression, watermarking, signage, and text extraction.
 trigger: model_decision
 ---
 > The TypeScript Type Definitions can be found at: ${relativeTypePath}


### PR DESCRIPTION
Change the package name in documetnation and examples to `@nutrient-sdk/dws-client-typescript`