### PR TITLE
Add User-Agent header to DWS requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ A Node.js TypeScript client library for [Nutrient Document Web Services (DWS) AP
 ## Installation
 
 ```bash
-npm install nutrient-dws-client-typescript
+npm install @nutrient-sdk/dws-client-typescript
 ```
 
 or
 
 ```bash
-yarn add nutrient-dws-client-typescript
+yarn add @nutrient-sdk/dws-client-typescript
 ```
 
 ## Integration with Coding Agents
@@ -147,7 +147,7 @@ import {
   APIError,
   AuthenticationError,
   NetworkError
-} from 'nutrient-dws-client-typescript';
+} from '@nutrient-sdk/dws-client-typescript';
 
 try {
   const result = await client.convert('file.docx', 'pdf');

--- a/src/__tests__/unit/http.test.ts
+++ b/src/__tests__/unit/http.test.ts
@@ -116,6 +116,7 @@ describe('HTTP Layer', () => {
           url: 'https://api.test.com/v1/account/info',
           headers: {
             Authorization: 'Bearer test-api-key',
+            'User-Agent': expect.stringMatching(/^nutrient-dws-client-typescript\/\d+\.\d+\.\d+$/),
           },
         }),
       );
@@ -566,6 +567,39 @@ describe('HTTP Layer', () => {
           url: 'https://api.nutrient.io/account/info',
         }),
       );
+    });
+
+    it('should include User-Agent header in all requests', async () => {
+      const mockResponse = {
+        data: { result: 'success' },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+      };
+
+      mockedAxios.mockResolvedValueOnce(mockResponse);
+
+      const config: RequestConfig<'GET', '/account/info'> = {
+        endpoint: '/account/info',
+        method: 'GET',
+        data: undefined,
+      };
+
+      await sendRequest(config, mockClientOptions, 'json');
+
+      expect(mockedAxios).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'User-Agent': expect.stringMatching(/^nutrient-dws-client-typescript\/\d+\.\d+\.\d+$/),
+          }),
+        }),
+      );
+
+      // Verify the User-Agent format is correct
+      const mockCalls = (mockedAxios as jest.Mock).mock.calls as unknown[][];
+      const firstCallArgs = mockCalls[0] as [{ headers?: { 'User-Agent'?: string } }];
+      const userAgent = firstCallArgs[0]?.headers?.['User-Agent'];
+      expect(userAgent).toMatch(/^nutrient-dws-client-typescript\/\d+\.\d+\.\d+$/);
     });
   });
 });

--- a/src/__tests__/unit/utils.test.ts
+++ b/src/__tests__/unit/utils.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for utility functions
+ */
+import { getLibraryVersion, getUserAgent } from '../../utils';
+
+describe('Utility Functions', () => {
+  describe('getLibraryVersion()', () => {
+    it('should return a valid semver version string', () => {
+      const version = getLibraryVersion();
+      
+      expect(version).toBeDefined();
+      expect(typeof version).toBe('string');
+      expect(version.length).toBeGreaterThan(0);
+      
+      // Check if it matches semver pattern (major.minor.patch)
+      const semverPattern = /^\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?$/;
+      expect(version).toMatch(semverPattern);
+    });
+
+    it('should return the version from package.json', () => {
+      const version = getLibraryVersion();
+      
+      // The version should match whatever is in package.json
+      // We don't hardcode the expected version to avoid breaking on version updates
+      expect(version).toMatch(/^\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?$/);
+      expect(version.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getUserAgent()', () => {
+    it('should return a properly formatted User-Agent string', () => {
+      const userAgent = getUserAgent();
+      
+      expect(userAgent).toBeDefined();
+      expect(typeof userAgent).toBe('string');
+      expect(userAgent.length).toBeGreaterThan(0);
+    });
+
+    it('should follow the expected User-Agent format', () => {
+      const userAgent = getUserAgent();
+      
+      // Should match: nutrient-dws-client-typescript/VERSION
+      const expectedPattern = /^nutrient-dws-client-typescript\/\d+\.\d+\.\d+(?:-[a-zA-Z0-9.-]+)?$/;
+      expect(userAgent).toMatch(expectedPattern);
+    });
+
+    it('should include the correct library name', () => {
+      const userAgent = getUserAgent();
+      
+      expect(userAgent).toContain('nutrient-dws-client-typescript');
+    });
+
+    it('should include the current library version', () => {
+      const userAgent = getUserAgent();
+      const version = getLibraryVersion();
+      
+      expect(userAgent).toContain(version);
+    });
+
+    it('should have consistent format across multiple calls', () => {
+      const userAgent1 = getUserAgent();
+      const userAgent2 = getUserAgent();
+      
+      expect(userAgent1).toBe(userAgent2);
+    });
+
+    it('should return the expected User-Agent format with current version', () => {
+      const userAgent = getUserAgent();
+      const version = getLibraryVersion();
+      
+      expect(userAgent).toBe(`nutrient-dws-client-typescript/${version}`);
+    });
+  });
+});

--- a/src/http.ts
+++ b/src/http.ts
@@ -10,6 +10,7 @@ import {
 } from './errors';
 import type { NutrientClientOptions } from './types';
 import type { Methods, Endpoints, RequestConfig, ApiResponse, ResponseTypeMap } from './types';
+import { getUserAgent } from './utils';
 
 /**
  * Sends HTTP request to Nutrient DWS Processor API
@@ -34,6 +35,7 @@ export async function sendRequest<Method extends Methods, Endpoint extends Endpo
       url,
       headers: {
         Authorization: `Bearer ${apiKey}`,
+        'User-Agent': getUserAgent(),
         ...config.headers,
       },
       timeout: clientOptions.timeout ?? 0, // No default timeout

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,3 +47,4 @@ export {
   type NormalizedFileData,
 } from './inputs';
 export { type ActionWithFileInput } from './build';
+export { getLibraryVersion, getUserAgent } from './utils';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Utility functions for the Nutrient DWS TypeScript Client
+ */
+export { getLibraryVersion, getUserAgent } from './version';

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,0 +1,20 @@
+/**
+ * Version utility functions
+ */
+import packageJson from '../../package.json';
+
+/**
+ * Gets the current version of the Nutrient DWS TypeScript Client library
+ * @returns The version string from package.json
+ */
+export function getLibraryVersion(): string {
+  return packageJson.version;
+}
+
+/**
+ * Creates a User-Agent string for HTTP requests
+ * @returns Formatted User-Agent string identifying this library
+ */
+export function getUserAgent(): string {
+  return `nutrient-dws-client-typescript/${getLibraryVersion()}`;
+}


### PR DESCRIPTION
Adds automatic User-Agent header to all HTTP requests made by the library to enable request identification and monitoring on the server side.

- HTTP Client: All requests now include User-Agent: nutrient-dws-client-typescript/VERSION
- Version Utils: Created src/utils/version.ts with getLibraryVersion() and getUserAgent() helper functions
- Tests: Added comprehensive test coverage with version-agnostic validation patterns

Tested integration tests locally.