### PR TITLE
chore(release): 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-05-29
+
 ### Added
 
 - First-class client support for the Data Extraction API (`POST /extraction/parse`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nutrient-sdk/dws-client-typescript",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nutrient-sdk/dws-client-typescript",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nutrient-sdk/dws-client-typescript",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Node.js TypeScript client library for Nutrient Document Web Services (DWS) API",
   "keywords": [
     "nutrient",


### PR DESCRIPTION
## Release 2.1.0

Minor release covering the new Data Extraction API support added since 2.0.0.

### Added
- First-class client support for the Data Extraction API (`POST /extraction/parse`): `NutrientClient.parse()`, `parseToMarkdown()`, `parseElements()`, the `extractApiKey` option, and associated public types / `extractComponents` namespace.

### Verification
- `npm run typecheck` ✓
- `npm run lint` ✓
- `npm run build` ✓
- `npm run test:unit` ✓ (292/292)

The `v2.1.0` tag will be created on the merge commit after this PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)