### PR TITLE
[DWS] SHA-pin GitHub Actions, and replace Snyk and Gitleaks with GitHub secret scanning

### DIFF
--- a/.github/SETUP_SECRETS.md
+++ b/.github/SETUP_SECRETS.md
@@ -14,9 +14,6 @@ Your Nutrient DWS Processor API key for running integration tests.
 ### 2. NPM_TOKEN (Optional)
 Required only if you want to automatically publish to NPM.
 
-### 3. SNYK_TOKEN (Optional)
-Required only if you want to run Snyk security scans.
-
 ## How to Add Secrets
 
 1. Go to your repository on GitHub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Use Node.js
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: '22.x'
         cache: 'npm'
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Use Node.js
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: '22.x'
         cache: 'npm'
@@ -72,10 +72,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -91,10 +91,10 @@ jobs:
     needs: [lint-and-type-check, generated-types-drift, unit-tests]
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Use Node.js
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: '22.x'
         cache: 'npm'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,10 +16,10 @@ jobs:
         node-version: [22.x, 24.x]
     
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/scheduled-integration-tests.yml
+++ b/.github/workflows/scheduled-integration-tests.yml
@@ -13,10 +13,10 @@ jobs:
       NUTRIENT_API_KEY: ${{ secrets.NUTRIENT_API_KEY }}
     
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     
     - name: Use Node.js
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: '22.x'
         cache: 'npm'
@@ -63,7 +63,7 @@ jobs:
     
     - name: Create issue if tests fail
       if: failure() && steps.test-run.outcome == 'failure'
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           const date = new Date().toISOString().split('T')[0];
@@ -104,7 +104,7 @@ jobs:
           }
     
     - name: Upload test artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: scheduled-integration-results-${{ github.run_number }}
@@ -115,7 +115,7 @@ jobs:
     
     - name: Notify on success after previous failure
       if: success() && steps.test-run.outcome == 'success'
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           // Close any open integration failure issues

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -71,12 +71,3 @@ jobs:
         echo "🔍 Running npm audit..."
         npm audit --production --audit-level=moderate || echo "⚠️ Audit found issues but continuing..."
       continue-on-error: true
-
-    - name: Run Snyk Security Scan
-      uses: snyk/actions/node@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
-      continue-on-error: true
-      env:
-        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      with:
-        args: --severity-threshold=high
-      if: env.SNYK_TOKEN != ''

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,12 +16,12 @@ jobs:
       security-events: write
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
 
     - name: Run Gitleaks
-      uses: gitleaks/gitleaks-action@v3
+      uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
@@ -55,10 +55,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Use Node.js
-      uses: actions/setup-node@v7
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: '22.x'
         cache: 'npm'
@@ -73,7 +73,7 @@ jobs:
       continue-on-error: true
 
     - name: Run Snyk Security Scan
-      uses: snyk/actions/node@master
+      uses: snyk/actions/node@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
       continue-on-error: true
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,23 +9,16 @@ on:
     - cron: '0 0 * * 0'  # Weekly on Sunday
 
 jobs:
+  # Broad credential detection is handled by GitHub secret scanning and push
+  # protection, which run on the repository itself. This job only covers the
+  # Nutrient-specific key formats that are not partner patterns.
   secret-scanning:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      security-events: write
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        fetch-depth: 0
-
-    - name: Run Gitleaks
-      uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
-      continue-on-error: true
 
     - name: Check for hardcoded secrets
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,9 +78,7 @@ server's contract; the fifth raises the minimum Node.js version to 22. See
   removes the flag, and it was already redundant under flat config — file
   coverage is unchanged at 31 files.
 - Updated GitHub Actions: `checkout`, `setup-node` and `upload-artifact` to
-  v7, `github-script` to v9, and `gitleaks-action` v2 → v3. The
-  `gitleaks-action` bump is not optional — v2 runs on the Node 20 Actions
-  runtime, which GitHub removes from hosted runners on 2026-09-16.
+  v7, and `github-script` to v9.
 - `npm run typecheck` now also typechecks the test suite. Test files were
   excluded from the only project `tsc --noEmit` ran against, so they were
   never typechecked outside of `ts-jest` at test time.


### PR DESCRIPTION
Follow-up to #16, which was approved with a request to SHA-pin the GitHub Actions.

## SHA pinning

All 20 `uses:` references across the four workflows now name a full commit SHA, with the release in a trailing comment so the version stays readable and Dependabot can still open update PRs.

| Action | Pin |
| --- | --- |
| `actions/checkout` | `3d3c42e5…` # v7.0.1 |
| `actions/setup-node` | `82076278…` # v7.0.0 |
| `actions/upload-artifact` | `043fb46d…` # v7.0.1 |
| `actions/github-script` | `3a2844b7…` # v9.0.0 |

A tag is a mutable pointer. Anyone who can move it can run their code with this repository's workflow token and secrets. A commit SHA cannot be moved.

## Removing two scans that never ran

**Snyk.** The step was gated behind `if: env.SNYK_TOKEN != ''`. No `SNYK_TOKEN` secret exists on the repository or the organization, so the guard was always false. `continue-on-error: true` meant it could not have failed the job even if it had run. `npm audit --production --audit-level=moderate` already runs two steps earlier in the same job, against the same dependency tree, and needs no token.

**Gitleaks.** The action requires a licence key for repositories owned by an organization. No `GITLEAKS_LICENSE` secret exists, so the step failed on every run, and `continue-on-error: true` hid that failure.

## What replaces them

GitHub secret scanning and push protection are now enabled on the repository. Push protection rejects a commit containing a recognised credential before it reaches the remote, where Gitleaks could only report a key that was already published. CodeQL default setup is also enabled, covering `actions` and `javascript-typescript`.

The workflow keeps its own check for the Nutrient key formats (`pdf_live_`, its base64 form, `sk_|pk_|nutr_sk_`). Those are not GitHub partner patterns, so nothing else looks for them.

`fetch-depth: 0` and the `security-events: write` permission went with the Gitleaks step. Only Gitleaks needed the full history and the SARIF upload.

## Verification

Local, on `fb2025a`:

```
$ npm run typecheck && npm run lint && npm run test:unit
> tsc --noEmit && tsc --noEmit --project src/__tests__/tsconfig.json
> eslint src
Test Suites: 11 passed, 11 total
Tests:       315 passed, 315 total
```

Every workflow file still parses, and no unpinned reference remains:

```
$ python3 -c "import yaml,glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"
$ grep -rn "uses:" .github/workflows/ | grep -vE "@[0-9a-f]{40} # v"
(no output)
```

Each pinned SHA was resolved from the GitHub API and confirmed to match the release named in its comment, for example:

```
$ gh api repos/actions/checkout/commits/v7.0.1 --jq .sha
3d3c42e5aac5ba805825da76410c181273ba90b1
```

The `checkout`, `setup-node`, `github-script` and `upload-artifact` pins were exercised end to end by CI on #16 before the merge: 11 checks passed, including unit tests on Node 22 and 24 across ubuntu, windows and macos.

Repository settings, applied and read back:

```
$ gh api repos/:owner/:repo --jq .security_and_analysis
secret_scanning:                 enabled
secret_scanning_push_protection: enabled

$ gh api repos/:owner/:repo/code-scanning/default-setup --jq .state
configured
```
